### PR TITLE
Make all entry points work as one-off scripts

### DIFF
--- a/ees_sharepoint/deindex.py
+++ b/ees_sharepoint/deindex.py
@@ -146,35 +146,30 @@ def start():
         or puts the connector to sleep"""
     logger.info('Starting the de-indexing...')
     config = Configuration("sharepoint_connector_config.yml", logger)
-    while True:
-        deindexer = Deindex(config)
-        try:
-            with open(IDS_PATH) as file:
-                ids = json.load(file)
-            for collection in config.get('sharepoint.site_collections'):
-                logger.info(
-                    'Starting the deindexing for site collection: %s' % collection)
-                if ids["delete_keys"].get(collection):
-                    ids = deindexer.deindexing_sites(collection, ids)
-                    ids = deindexer.deindexing_lists(collection, ids)
-                    ids = deindexer.deindexing_items(collection, ids, "list_items")
-                    ids = deindexer.deindexing_items(collection, ids, "drive_items")
-                else:
-                    logger.info("No objects present to be deleted for the collection: %s" % collection)
-            ids["delete_keys"] = {}
-            with open(IDS_PATH, "w") as file:
-                try:
-                    json.dump(ids, file, indent=4)
-                except ValueError as exception:
-                    logger.exception(
-                        "Error while updating the doc_id json file. Error: %s", exception
-                    )
-        except FileNotFoundError as exception:
-            logger.warnig(
-                "[Fail] File doc_id.json is not present, none of the objects are indexed. Error: %s"
-                % exception
-            )
-        deindexing_interval = config.get_value('deletion_interval')
-        # TODO: need to use schedule instead of time.sleep
-        logger.info('Sleeping..')
-        time.sleep(deindexing_interval * 60)
+    deindexer = Deindex(config)
+    try:
+        with open(IDS_PATH) as file:
+            ids = json.load(file)
+        for collection in config.get('sharepoint.site_collections'):
+            logger.info(
+                'Starting the deindexing for site collection: %s' % collection)
+            if ids["delete_keys"].get(collection):
+                ids = deindexer.deindexing_sites(collection, ids)
+                ids = deindexer.deindexing_lists(collection, ids)
+                ids = deindexer.deindexing_items(collection, ids, "list_items")
+                ids = deindexer.deindexing_items(collection, ids, "drive_items")
+            else:
+                logger.info("No objects present to be deleted for the collection: %s" % collection)
+        ids["delete_keys"] = {}
+        with open(IDS_PATH, "w") as file:
+            try:
+                json.dump(ids, file, indent=4)
+            except ValueError as exception:
+                logger.exception(
+                    "Error while updating the doc_id json file. Error: %s", exception
+                )
+    except FileNotFoundError as exception:
+        logger.warning(
+            "[Fail] File doc_id.json is not present, none of the objects are indexed. Error: %s"
+            % exception
+        )

--- a/ees_sharepoint/sync_user_permissions.py
+++ b/ees_sharepoint/sync_user_permissions.py
@@ -150,21 +150,9 @@ def start():
     logger.info("Starting the permission indexing..")
     config = Configuration("sharepoint_connector_config.yml", logger)
 
-    while True:
-        enable_permission = config.get_value("enable_document_permission")
-        if not enable_permission:
-            logger.info('Exiting as the enable permission flag is set to False')
-            raise PermissionSyncDisabledException
-        permission_indexer = SyncUserPermission(config)
-        permission_indexer.sync_permissions()
-
-        try:
-            sync_permission_interval = int(
-                config.get_value('sync_permission_interval'))
-        except Exception as exception:
-            logger.warning('Error while converting the parameter sync_permission_interval: %s to integer. Considering the default value as 60 minutes. Error: %s' % (
-                sync_permission_interval, exception))
-
-        # TODO: need to use schedule instead of time.sleep
-        logger.info('Sleeping..')
-        time.sleep(sync_permission_interval * 60)
+    enable_permission = config.get_value("enable_document_permission")
+    if not enable_permission:
+        logger.info('Exiting as the enable permission flag is set to False')
+        raise PermissionSyncDisabledException
+    permission_indexer = SyncUserPermission(config)
+    permission_indexer.sync_permissions()

--- a/sharepoint_connector_config.yml
+++ b/sharepoint_connector_config.yml
@@ -40,14 +40,6 @@ objects:
 start_time : "2021-08-16T13:58:12Z"
 #The timestamp before which all the updated objects need to be fetched i.e. the connector won’t fetch any object updated/created after the end_time. By default, all the objects updated/added till the current time are fetched
 end_time : "2021-08-31T13:58:12Z"
-#The interval after which the connector looks for new/updated objects from SharePoint. The unit of the interval is minutes. By default, the interval is considered to be 60 minutes
-indexing_interval: 60
-#The interval after which the connector looks for the deleted objects from SharePoint. The unit of the interval is minutes. By default, the interval is considered to be 60 minutes
-deletion_interval: 60
-#The interval after which the connector looks for new/updated user permissions from SharePoint. The unit of the interval is minutes. By default, the interval is considered to be 60 minutes
-sync_permission_interval: 60
-#The interval after which the connector fetches all the objects from sharepoint server from a given start_time in the configuration file to the current time
-full_sync_interval: 2880
 #The level of the logs the user wants to use in the log files. The possible values include: debug, info, warn, error. By default, the level is info
 log_level: info
 #The number of retries to perform in case of server error. The connector will use exponential backoff for retry mechanism


### PR DESCRIPTION
This change removes `while True:` loops making scripts work only once when ran instead of attempting to run again after scheduled intervals.

Actual scheduling/re-running the scripts can be managed by `cron`, so this change simplifies the code and makes it more predictable - relying on `Thread.sleep` with a constant (in the context of execution) value will make the interval between syncs depend on the time it takes to execute the sync:

If the sync takes 1 hour to execute and interval between syncs is set to 1 hour, then actual interval between syncs will be 2 hours. It can be confusing, as it works differently from how Workplace Search does indexing.