### PR TITLE
Updated Makefile to upgrade pip3 version before installing requirements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ help:
 	touch .venv_init
 
 .installed: .venv_init
+	${VENV_DIRECTORY}/bin/${PIP} install -U pip
 	${VENV_DIRECTORY}/bin/${PIP} install -r requirements.txt
 	touch .installed
 


### PR DESCRIPTION
The OS where the connector gets installed might have an outdated pip version which would cause errors while installing the requirements for the connector, for example, Ubuntu 18.04 ships quite an older pip version i.e. 9.0.1, and installing the connector's dependencies on a fresh Ubuntu 18.04 raises RustException because of missing setuptools_rust module.

This PR contains changes to avoid this issue, i.e. upgrading the pip to the latest version before installing the requiements.txt