### PR TITLE
Switch to public CI cluster

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -1,7 +1,7 @@
 ---
 
 - meta:
-    cluster: swiftype-ci
+    cluster: devops-ci
 
 - job:
     node: "linux && immutable"

--- a/.ci/jobs/ent-search-connector-sharepoint-server-2016.yml
+++ b/.ci/jobs/ent-search-connector-sharepoint-server-2016.yml
@@ -1,7 +1,7 @@
 ---
 
 - job:
-    name: ent-search-connectors/sharepoint-server-2016
+    name: ent-search-ingestion/sharepoint-server-2016-connector
     description: "Runs tests and linters against the repository."
     project-type: multibranch
     node: master


### PR DESCRIPTION
As repo is becoming public, we want our CI run results to be accessible by people outside of Elastic.

This PR makes a change to run CI jobs at `devops-ci` cluster (recommended to us, as it's a public cluster other Elastic products use and setting up a new public cluster just for us is a task requiring quite some effort)

Also changed the job name to mention ingestion instead of connectors.