### PR TITLE
Updating README and setup to restrict Python version>=3.8

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -17,7 +17,7 @@ Requirements
 
 This connector requires:
 
-* Python >= 3.6
+* Python >= 3.8
 * Workplace Search >= 7.13.0 and a Platinum+ license.
 * Java 7 or higher
 * SharePoint Server 2016

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,8 @@
 import sys
 from setuptools import setup, find_packages
 
-if sys.version_info < (3, 6):
-    raise ValueError("Requires Python 3.6 or superior")
+if sys.version_info < (3, 8):
+    raise ValueError("Requires Python 3.8 or superior")
 
 from ees_sharepoint import __version__  # NOQA
 
@@ -33,8 +33,6 @@ classifiers = [
     "Programming Language :: Python",
     "Development Status :: 5 - Production/Stable",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.6",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
 ]


### PR DESCRIPTION
Since the connector uses some imports and statements that are supported in Python versions>=3.8, updated the README.rst and setup.py to add validation and restrict the user for Python versions>=3.8