### PR TITLE
Fixes for issues found on testing

### DIFF
--- a/ees_sharepoint/adapter.py
+++ b/ees_sharepoint/adapter.py
@@ -5,7 +5,7 @@
 #
 """Module containing default schema for data uploaded to Enterprise Search.
 
-This module contains definition of detault schema for the data
+This module contains definition of default schema for the data
 that will be uploaded to Elastic Enterprise Search per each Sharepoint Server object.
 
 Keys for each object represent the fields that will be uploaded to Enterprise Search

--- a/ees_sharepoint/deletion_sync_command.py
+++ b/ees_sharepoint/deletion_sync_command.py
@@ -13,7 +13,7 @@ import os
 import requests
 
 from .base_command import BaseCommand
-
+from .utils import split_in_chunks
 
 IDS_PATH = os.path.join(os.path.dirname(__file__), 'doc_id.json')
 # By default, Enterprise Search configuration has a maximum allowed limit set to 100 documents for an api request
@@ -32,16 +32,6 @@ class DeletionSyncCommand(BaseCommand):
         config = self.config
 
         self.ws_source = config.get_value("workplace_search.source_id")
-
-    def split_in_chunks(self, doc):
-        """This method splits a list into separate chunks with maximum size
-            as BATCH_SIZE
-            :param doc: list of documents
-        """
-        document_list = []
-        for i in range(0, len(doc), BATCH_SIZE):
-            document_list.append(doc[i:i + BATCH_SIZE])
-        return document_list
 
     def deindexing_items(self, collection, ids, key):
         """Fetches the id's of deleted items from the sharepoint server and
@@ -68,7 +58,7 @@ class DeletionSyncCommand(BaseCommand):
                         if resp.status_code == requests.codes['not_found'] or result == []:
                             doc.append(item_id)
                     if doc:
-                        for chunk in self.split_in_chunks(doc):
+                        for chunk in split_in_chunks(doc, BATCH_SIZE):
                             self.workplace_search_client.delete_documents(
                                 content_source_id=self.ws_source,
                                 document_ids=chunk)
@@ -111,7 +101,7 @@ class DeletionSyncCommand(BaseCommand):
                     resp = self.sharepoint_client.get(url, '', "deindex")
                     if resp is not None and resp.status_code == requests.codes['not_found']:
                         doc.append(list_id)
-                for chunk in self.split_in_chunks(doc):
+                for chunk in self.split_in_chunks(doc, BATCH_SIZE):
                     self.workplace_search_client.delete_documents(
                         content_source_id=self.ws_source,
                         document_ids=chunk)
@@ -142,7 +132,7 @@ class DeletionSyncCommand(BaseCommand):
                 resp = self.sharepoint_client.get(url, '', "deindex")
                 if resp is not None and resp.status_code == requests.codes['not_found']:
                     doc.append(site_id)
-            for chunk in self.split_in_chunks(doc):
+            for chunk in self.split_in_chunks(doc, BATCH_SIZE):
                 self.workplace_search_client.delete_documents(
                     content_source_id=self.ws_source,
                     document_ids=chunk)

--- a/ees_sharepoint/deletion_sync_command.py
+++ b/ees_sharepoint/deletion_sync_command.py
@@ -101,7 +101,7 @@ class DeletionSyncCommand(BaseCommand):
                     resp = self.sharepoint_client.get(url, '', "deindex")
                     if resp is not None and resp.status_code == requests.codes['not_found']:
                         doc.append(list_id)
-                for chunk in self.split_in_chunks(doc, BATCH_SIZE):
+                for chunk in split_in_chunks(doc, BATCH_SIZE):
                     self.workplace_search_client.delete_documents(
                         content_source_id=self.ws_source,
                         document_ids=chunk)
@@ -132,7 +132,7 @@ class DeletionSyncCommand(BaseCommand):
                 resp = self.sharepoint_client.get(url, '', "deindex")
                 if resp is not None and resp.status_code == requests.codes['not_found']:
                     doc.append(site_id)
-            for chunk in self.split_in_chunks(doc, BATCH_SIZE):
+            for chunk in split_in_chunks(doc, BATCH_SIZE):
                 self.workplace_search_client.delete_documents(
                     content_source_id=self.ws_source,
                     document_ids=chunk)

--- a/ees_sharepoint/fetch_index.py
+++ b/ees_sharepoint/fetch_index.py
@@ -592,9 +592,8 @@ def start(indexing_type, config, logger, workplace_search_client, sharepoint_cli
 
             storage_with_collection["global_keys"][collection] = storage.copy()
 
-            check.set_checkpoint(collection, start_time, indexing_type)
+            check.set_checkpoint(collection, end_time, indexing_type)
     except Exception as exception:
-        check.set_checkpoint(collection, end_time, indexing_type)
         raise exception
 
     with open(IDS_PATH, "w") as file:

--- a/ees_sharepoint/fetch_index.py
+++ b/ees_sharepoint/fetch_index.py
@@ -19,7 +19,7 @@ from tika.tika import TikaException
 
 from .checkpointing import Checkpoint
 from .usergroup_permissions import Permissions
-from .utils import encode, extract
+from .utils import encode, extract, split_in_chunks
 from . import adapter
 
 IDS_PATH = os.path.join(os.path.dirname(__file__), 'doc_id.json')
@@ -31,7 +31,7 @@ SITES = "sites"
 LISTS = "lists"
 LIST_ITEMS = "list_items"
 DRIVE_ITEMS = "drive_items"
-DOCUMENT_SIZE = 100
+BATCH_SIZE = 100
 DATETIME_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 
@@ -79,8 +79,7 @@ class FetchIndex:
         """
         if document:
             total_documents_indexed = 0
-            document_list = [document[i * DOCUMENT_SIZE:(i + 1) * DOCUMENT_SIZE] for i in range((len(document) + DOCUMENT_SIZE - 1) // DOCUMENT_SIZE)]
-            for chunk in document_list:
+            for chunk in split_in_chunks(document, BATCH_SIZE):
                 response = self.workplace_search_client.index_documents(
                     content_source_id=self.ws_source,
                     documents=chunk

--- a/ees_sharepoint/schema.py
+++ b/ees_sharepoint/schema.py
@@ -156,7 +156,7 @@ schema = {
     'log_level': {
         'required': False,
         'type': 'string',
-        'default': 'info',
+        'default': 'INFO',
         'allowed': ['DEBUG', 'INFO', 'WARN', 'ERROR']
     },
     'retry_count': {

--- a/ees_sharepoint/utils.py
+++ b/ees_sharepoint/utils.py
@@ -28,3 +28,17 @@ def encode(object_name):
         :param object_name: name that contains special characters"""
     name = urllib.parse.quote(object_name, safe="'")
     return name.replace("'", "''")
+
+
+def split_in_chunks(input_list, chunk_size):
+    """This method splits a list into separate chunks with maximum size
+        as chunk_size
+        :param input_list: list to be partitioned into chunks
+        :param chunk_size: maximum size of a chunk
+        Returns:
+            :list_of_chunks: list containing the chunks
+    """
+    list_of_chunks = []
+    for i in range(0, len(input_list), chunk_size):
+        list_of_chunks.append(input_list[i:i + chunk_size])
+    return list_of_chunks


### PR DESCRIPTION
Rectify checkpoint-saving mechanism

Expected result:
When no exception occurs, the connector should save the end_time in the checkpoint file. 
In case of any exception encountered, the checkpoint should not be saved or should be reverted back to start time. 

Actual result: 
In case of exception,  Checkpoint.json file gets updated as checkpoint was saved with end_time, and when no exception is encountered, the checkpoint file is getting the start_time (same as the previously saved checkpoint time, i.e. no updation)

Changes made:
In the present code in the 'fetch_index.py' file,
In case of exception checkpoint is not set and line
 `check.set_checkpoint(collection, start_time, indexing_type)` is changed to `check.set_checkpoint(collection, end_time, indexing_type)`.

Deletion of large documents

By default, Enterprise Search configuration has a maximum allowed limit set to 100 documents for an API request. 

Issue: Documents were not getting deleted. 
Changes made:
Calling delete_documents APIs with documents in batch size of 100

Other changes: 
Default value of log level in schema should be in uppercase