### PR TITLE
Fix CI

### DIFF
--- a/.ci/jobs/ent-search-connector-sharepoint-server.yml
+++ b/.ci/jobs/ent-search-connector-sharepoint-server.yml
@@ -1,16 +1,16 @@
 ---
 
 - job:
-    name: ent-search-ingestion/sharepoint-server-2016-connector
+    name: ent-search-ingestion/sharepoint-server-connector
     description: "Runs tests and linters against the repository."
     project-type: multibranch
     node: master
     concurrent: true
-    script-path: .ci/pipelines/ent-search-connector-sharepoint-server-2016.groovy
+    script-path: .ci/pipelines/ent-search-connector-sharepoint-server.groovy
     prune-dead-branches: true
     scm:
       - github:
-          repo: enterprise-search-sharepoint-server-2016-connector
+          repo: enterprise-search-sharepoint-server-connector
           repo-owner: elastic
           disable-pr-notifications: true
           branch-discovery: all

--- a/.ci/pipelines/ent-search-connector-sharepoint-server.groovy
+++ b/.ci/pipelines/ent-search-connector-sharepoint-server.groovy
@@ -9,8 +9,8 @@
 
 eshPipeline(
     timeout: 45,
-    project_name: 'Enterprise Search Sharepoint Server 2016 Connector',
-    repository: 'enterprise-search-sharepoint-server-2016-connector',
+    project_name: 'Enterprise Search Sharepoint Server Connector',
+    repository: 'enterprise-search-sharepoint-server-connector',
     stages: [
         [
             name: 'Linting',


### PR DESCRIPTION
.ci files were pointing to the old repo name (with `-2016` in the name), this PR changes it, also updating the names of CI scripts to not include `-2016` suffix.