### PR TITLE
add-thread-count-fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,7 +593,7 @@ The number of threads the connector will run parallelly for indexing documents t
 enterprise_search_sync_thread_count: 5
 ```
 
-For the Linux distribution with atleast 2 GB RAM and 4 vCPUs, you can increase the thread counts if the overall CPU and RAM are under utilized i.e. below 60-70%.
+For a Linux distribution with at least 2 GB RAM and 4 vCPUs, you can increase thread counts— if the overall CPU and RAM are underutilized, i.e. below 60-70%.
 
 #### `sharepoint_workplace_user_mapping`
 

--- a/README.md
+++ b/README.md
@@ -579,7 +579,7 @@ retry_count: 3
 
 #### `sharepoint_sync_thread_count`
 
-The number of threads the connector will run parallelly for fetching documents from the SharePoint server. By default, the connector uses 5 threads.
+The number of threads the connector will run in parallel when fetching documents from the SharePoint server. By default, the connector uses 5 threads.
 
 ```yaml
 sharepoint_sync_thread_count: 5

--- a/README.md
+++ b/README.md
@@ -577,6 +577,24 @@ The number of retries to perform when there is a server error. The connector app
 retry_count: 3
 ```
 
+#### `sharepoint_sync_thread_count`
+
+The number of threads the connector will run parallelly for fetching documents from the SharePoint server. By default, the connector uses 5 threads.
+
+```yaml
+sharepoint_sync_thread_count: 5
+```
+
+#### `enterprise_search_sync_thread_count`
+
+The number of threads the connector will run parallelly for indexing documents to the Enterprise Search instance. By default, the connector uses 5 threads.
+
+```yaml
+enterprise_search_sync_thread_count: 5
+```
+
+For the Linux distribution with atleast 2 GB RAM and 4 vCPUs, you can increase the thread counts if the overall CPU and RAM are under utilized i.e. below 60-70%.
+
 #### `sharepoint_workplace_user_mapping`
 
 The pathname of the CSV file containing the user identity mappings for [document-level permissions (DLP)](#use-document-level-permissions-dlp).

--- a/README.md
+++ b/README.md
@@ -587,7 +587,7 @@ sharepoint_sync_thread_count: 5
 
 #### `enterprise_search_sync_thread_count`
 
-The number of threads the connector will run parallelly for indexing documents to the Enterprise Search instance. By default, the connector uses 5 threads.
+The number of threads the connector will run in parallel when indexing documents to the Enterprise Search instance. By default, the connector uses 5 threads.
 
 ```yaml
 enterprise_search_sync_thread_count: 5


### PR DESCRIPTION
Following fields are added in the README: 

sharepoint_sync_thread_count

enterprise_search_sync_thread_count