### PR TITLE
Fix for Bootstrap command giving TypeError with user args

### DIFF
--- a/ees_sharepoint/enterprise_search_wrapper.py
+++ b/ees_sharepoint/enterprise_search_wrapper.py
@@ -23,7 +23,7 @@ class EnterpriseSearchWrapper:
         if self.version >= ENTERPRISE_V8:
             if hasattr(args, "user") and args.user:
                 self.workplace_search_client = WorkplaceSearch(
-                    self.host, bearer_auth=(args.user, args.password)
+                    self.host, basic_auth=(args.user, args.password)
                 )
             else:
                 self.workplace_search_client = WorkplaceSearch(


### PR DESCRIPTION
We have recently added support for Enterprise Search version 8.0+ which requires bearer_auth to be a string. So Bootstrap Command will now give below error while running Bootstrap command with user argument. 

![image](https://user-images.githubusercontent.com/90465691/172341227-12e2c87c-b8c2-4548-a176-4f23d22581cd.png)

Hence we will now have to pass the username and password in basic_auth. 
