### PR TITLE
Add support for custom certificates and option to toggle SSL verification

### DIFF
--- a/ees_sharepoint/schema.py
+++ b/ees_sharepoint/schema.py
@@ -48,6 +48,16 @@ schema = {
         'required': True,
         'type': 'string'
     },
+    "sharepoint.secure_connection": {
+        "required": True,
+        "type": "boolean",
+        "default": True,
+    },
+    "sharepoint.certificate_path": {
+        "required": False,
+        "type": "string",
+        "empty": True
+    },
     'enable_document_permission': {
         'required': False,
         'type': 'boolean',

--- a/ees_sharepoint/sharepoint_client.py
+++ b/ees_sharepoint/sharepoint_client.py
@@ -21,6 +21,8 @@ class SharePoint:
         self.domain = config.get_value("sharepoint.domain")
         self.username = config.get_value("sharepoint.username")
         self.password = config.get_value("sharepoint.password")
+        self.secure_connection = config.get_value("sharepoint.secure_connection")
+        self.certificate_path = config.get_value("sharepoint.certificate_path")
 
     def get(self, rel_url, query, param_name):
         """ Invokes a GET call to the Sharepoint server
@@ -47,12 +49,17 @@ class SharePoint:
             url = f"{self.host}/{rel_url}{paginate_query}"
             skip += 5000
             retry = 0
+            if self.secure_connection and self.certificate_path:
+                verify = self.certificate_path
+            else:
+                verify = self.secure_connection
             while retry <= self.retry_count:
                 try:
                     response = requests.get(
                         url,
                         auth=HttpNtlmAuth(self.domain + "\\" + self.username, self.password),
-                        headers=request_headers
+                        headers=request_headers,
+                        verify=verify,
                     )
                     if response.ok:
                         if param_name in ["sites", "lists"] and response:

--- a/sharepoint_server_connector.yml
+++ b/sharepoint_server_connector.yml
@@ -12,6 +12,10 @@ sharepoint.host_url: http://sharepoint-host:14682/
 #Specifies the site collections whose contents the user wants to fetch and index.
 sharepoint.site_collections:
     - Connector
+#Validate the SSL certificate if host is secured. Specify Yes if host is secured and want to validate the SSL certificate, else No.
+sharepoint.secure_connection: Yes
+#The path of the SSL certificate to establish a secure connection with SharePoint server
+sharepoint.certificate_path: ""
 #Workplace Search configuration settings
 #Api key for Workplace search authentication
 workplace_search.api_key: "12345678"


### PR DESCRIPTION
## This PR addresses the following changes:

- Allow user to provide custom CA certificates for secure sharepoint servers. The path for the certificate can be added in the field `certificate_path` in the configuration yml file
- Allow user to enable/disable SSL verification via configuration yml file. 

## Closes #57 