### PR TITLE
Fix list-items and drive-items getting indexed every time

### DIFF
--- a/ees_sharepoint/sync_sharepoint.py
+++ b/ees_sharepoint/sync_sharepoint.py
@@ -605,10 +605,12 @@ class SyncSharepoint:
             lists_details.update(result[0])
             libraries_details.update(result[1])
 
-        list_items = split_documents_into_equal_chunks(lists_details, thread_count)
-        producer(thread_count, self.fetch_and_append_list_items_to_queue, [ids], list_items, wait=True)
+        if LIST_ITEMS in self.objects:
+            list_items = split_documents_into_equal_chunks(lists_details, thread_count)
+            producer(thread_count, self.fetch_and_append_list_items_to_queue, [ids], list_items, wait=True)
 
         # Fetch library details
-        libraries_items = split_documents_into_equal_chunks(libraries_details, thread_count)
-        producer(thread_count, self.fetch_and_append_drive_items_to_queue, [ids], libraries_items, wait=True)
+        if DRIVE_ITEMS in self.objects:
+            libraries_items = split_documents_into_equal_chunks(libraries_details, thread_count)
+            producer(thread_count, self.fetch_and_append_drive_items_to_queue, [ids], libraries_items, wait=True)
         return ids


### PR DESCRIPTION
This PR addresses the following change:

- Added a fix for list-items and drive-items getting indexed regardless of being present/absent in config file.

## Expected Result:

Only those objects should be indexed that are present in `objects` field in the config yml. 

## Root cause: 

The conditions to check if list-items and drive-items are present in config yml were missing.
