### PR TITLE
Fix Incorrect count of documents in the logger

### DIFF
--- a/ees_sharepoint/sync_sharepoint.py
+++ b/ees_sharepoint/sync_sharepoint.py
@@ -522,7 +522,7 @@ class SyncSharepoint:
         """
         start_time, end_time = duration[0], duration[1]
         parent_site_url = f"/sites/{collection}"
-        sites_path = [{parent_site_url: self.end_time}]
+        sites_path = []
         sites, documents = self.fetch_sites(
             parent_site_url,
             {},
@@ -590,7 +590,7 @@ class SyncSharepoint:
         time_range_list = [(date_ranges[num], date_ranges[num + 1]) for num in range(0, thread_count)]
         sites = producer(thread_count, self.fetch_and_append_sites_to_queue,
                          [ids, collection], time_range_list, wait=True)
-        all_sites = []
+        all_sites = [{f"/sites/{collection}": self.end_time}]
         for site in sites:
             all_sites.extend(site)
 


### PR DESCRIPTION
This PR addresses the following change:

- Fix Incorrect count of documents in the logger.

## Expected Result:

- Count of documents indexed in the logger should be same as count of documents in the Enterprise Search

## Root cause:

 Site-collection was appended multiple times in the sites lists due to which Lists and Items directly inside
collection were being fetched in every thread leading to redundancy. To resolve this, we append the site-collection after
fetching all the sites.