### PR TITLE
Fix subsites not getting indexed

### DIFF
--- a/ees_sharepoint/sync_sharepoint.py
+++ b/ees_sharepoint/sync_sharepoint.py
@@ -107,7 +107,7 @@ class SyncSharepoint:
             adapter_schema["id"] = field_id
         return adapter_schema
 
-    def fetch_sites(self, parent_site_url, sites, ids, index, start_time, end_time):
+    def fetch_sites(self, parent_site_url, sites, ids, index, start_time, end_time, document_list):
         """This method fetches sites from a collection and invokes the
         index permission method to get the document level permissions.
         If the fetching is not successful, it logs proper message.
@@ -117,8 +117,10 @@ class SyncSharepoint:
         :param index: index, boolean value
         :param start_time: start time for fetching the data
         :param end_time: end time for fetching the data
+        :param document_list: list of document of sites
         Returns:
-            document: response of sharepoint GET call, with fields specified in the schema
+            sites: list of site paths
+            documents: response of sharepoint GET call with fields specified in the schema
         """
         rel_url = f"{parent_site_url}/_api/web/webs"
         self.logger.info("Fetching the sites detail from url: %s" % (rel_url))
@@ -137,7 +139,6 @@ class SyncSharepoint:
             % len(response_data)
         )
         schema = self.get_schema_fields(SITES)
-        document = []
 
         if index:
             for i, _ in enumerate(response_data):
@@ -151,14 +152,14 @@ class SyncSharepoint:
                     doc["_allow_permissions"] = self.fetch_permissions(
                         key=SITES, site=response_data[i]["ServerRelativeUrl"]
                     )
-                document.append(doc)
+                document_list.append(doc)
                 ids["sites"].update({doc["id"]: response_data[i]["ServerRelativeUrl"]})
         for result in response_data:
             site_server_url = result.get("ServerRelativeUrl")
             sites.update({site_server_url: result.get("LastItemModifiedDate")})
-            self.fetch_sites(site_server_url, sites, ids, index, start_time, end_time)
+            self.fetch_sites(site_server_url, sites, ids, index, start_time, end_time, document_list)
 
-        documents = {"type": SITES, "data": document}
+        documents = {"type": SITES, "data": document_list}
         return sites, documents
 
     def fetch_lists(self, sites, ids, index):
@@ -530,6 +531,7 @@ class SyncSharepoint:
             (SITES in self.objects),
             start_time,
             end_time,
+            []
         )
         if documents:
             self.queue.put(documents)


### PR DESCRIPTION
This PR addresses the following change:

- Fix sub-sites not getting indexed in the Enterprise Search

## Expected Result:

- Subsites should be indexed in the Enterprise Search

## Root cause: 

Sub-sites are fetched in recursive calls of `fetch_sites` method. However, subsequent sub-sites fetched were not
being stored due to which they were not indexed into the Enterprise Search.

### Closes #58 