### PR TITLE
Fix for permission sync marked successful even if Enterprise Search throws error

### DIFF
--- a/ees_sharepoint/permission_sync_command.py
+++ b/ees_sharepoint/permission_sync_command.py
@@ -88,13 +88,7 @@ class PermissionSyncCommand(BaseCommand):
         :param permissions: dictionary of dictionaries containing permissions of all the users in each site-collection."""
         for collection in self.site_collections:
             for user_name, permission_list in permissions[collection].items():
-                try:
-                    self.workplace_search_custom_client.add_permissions(user_name, permission_list)
-                except Exception as exception:
-                    self.logger.exception(
-                        "Error while indexing the permissions for user: %s to the workplace. Error: %s"
-                        % (user_name, exception)
-                    )
+                self.workplace_search_custom_client.add_permissions(user_name, permission_list)
 
     def sync_permissions(self):
         """This method when invoked, checks the permission of SharePoint users and update those user

--- a/ees_sharepoint/permission_sync_command.py
+++ b/ees_sharepoint/permission_sync_command.py
@@ -90,7 +90,6 @@ class PermissionSyncCommand(BaseCommand):
             for user_name, permission_list in permissions[collection].items():
                 try:
                     self.workplace_search_custom_client.add_permissions(user_name, permission_list)
-                    self.logger.info("Successfully indexed the permissions for user %s to the workplace" % (user_name))
                 except Exception as exception:
                     self.logger.exception(
                         "Error while indexing the permissions for user: %s to the workplace. Error: %s"


### PR DESCRIPTION
## Closes #66 

The logger was not required as the succesfully indexed logger was already present and being handled from enterprise_search_wrapper file at line:  https://github.com/elastic/enterprise-search-sharepoint-server-connector/blob/1490d01510d3c7aaa609a0e02b6e2438b6013d86/ees_sharepoint/enterprise_search_wrapper.py#L83

The extra logger at permission_sync_command file was the one getting printed even when the error is thrown by the Enterprise Search. Hence, removing it.

