### PR TITLE
Prevent hidden objects from being indexed

### DIFF
--- a/ees_sharepoint/sharepoint_client.py
+++ b/ees_sharepoint/sharepoint_client.py
@@ -114,12 +114,10 @@ class SharePoint:
             Returns:
                 query: query for each object"""
         query = ""
-        if param_name in ["sites", "lists"]:
+        if param_name == "sites":
             query = f"?$filter=(LastItemModifiedDate ge datetime'{start_time}') and (LastItemModifiedDate le datetime'{end_time}')"
+        elif param_name == "lists":
+            query = f"?$expand=RootFolder&$filter=(LastItemModifiedDate ge datetime'{start_time}') and (LastItemModifiedDate le datetime'{end_time}') and (Hidden eq false)"
         else:
-            query = f"$filter=(Modified ge datetime'{start_time}') and (Modified le datetime'{end_time}')"
-            if param_name == "list_items":
-                query = "?" + query
-            else:
-                query = "&" + query
+            query = f"&$filter=(Modified ge datetime'{start_time}') and (Modified le datetime'{end_time}')"
         return query

--- a/ees_sharepoint/sync_sharepoint.py
+++ b/ees_sharepoint/sync_sharepoint.py
@@ -7,7 +7,6 @@
 
 It's possible to run full syncs and incremental syncs with this module."""
 import os
-import re
 import threading
 from urllib.parse import urljoin
 
@@ -223,7 +222,7 @@ class SyncSharepoint:
                                 list_url=response_data[i]["ParentWebUrl"],
                                 itemid=None,
                             )
-            
+
                         doc["url"] = urljoin(
                             self.sharepoint_host,
                             relative_url,


### PR DESCRIPTION
## Closes #65 

### The following changes have been committed in this PR:

- Avoid hidden objects from getting indexed
- Use relative url directly from the response body using properties: `FileRef/ServerRelativeUrl` instead of creating via code 